### PR TITLE
Show specific error when history files are in HTML format

### DIFF
--- a/packages/python/port/rendering.py
+++ b/packages/python/port/rendering.py
@@ -22,6 +22,42 @@ class PageRenderer:
         page = props.PropsUIPageDataSubmission("Zip", header, body)
         return CommandUIRender(page)
 
+    def html_format_retry_page(self):
+        text = props.Translatable(
+            {
+                "en": "Your YouTube data file contains history in HTML format, but JSON format is required. To fix this: go back to Google Takeout, select YouTube data, click 'Multiple formats', and change History from HTML to JSON. Then re-download and try again.",
+                "de": "Ihre YouTube-Datendatei enthält den Verlauf im HTML-Format, aber das JSON-Format ist erforderlich. Um dies zu beheben: Gehen Sie zu Google Takeout, wählen Sie YouTube-Daten aus, klicken Sie auf 'Mehrere Formate' und ändern Sie den Verlauf von HTML zu JSON. Laden Sie dann erneut herunter und versuchen Sie es noch einmal.",
+                "it": "Il file di dati YouTube contiene la cronologia in formato HTML, ma è richiesto il formato JSON. Per risolvere il problema: torna a Google Takeout, seleziona i dati YouTube, fai clic su 'Più formati' e cambia la cronologia da HTML a JSON. Quindi scarica nuovamente e riprova.",
+                "es": "Su archivo de datos de YouTube contiene el historial en formato HTML, pero se requiere el formato JSON. Para solucionar esto: vuelva a Google Takeout, seleccione los datos de YouTube, haga clic en 'Varios formatos' y cambie el historial de HTML a JSON. Luego vuelva a descargar e inténtelo de nuevo.",
+                "nl": "Uw YouTube-gegevensbestand bevat de geschiedenis in HTML-formaat, maar het JSON-formaat is vereist. Om dit op te lossen: ga terug naar Google Takeout, selecteer YouTube-gegevens, klik op 'Meerdere indelingen' en wijzig Geschiedenis van HTML naar JSON. Download vervolgens opnieuw en probeer het opnieuw.",
+                "ro": "Fișierul dvs. de date YouTube conține istoricul în format HTML, dar este necesar formatul JSON. Pentru a remedia acest lucru: reveniți la Google Takeout, selectați datele YouTube, faceți clic pe 'Mai multe formate' și schimbați Istoricul din HTML în JSON. Apoi descărcați din nou și încercați din nou.",
+                "lt": "Jūsų 'YouTube' duomenų faile istorija yra HTML formatu, tačiau reikalingas JSON formatas. Norėdami tai ištaisyti: grįžkite į 'Google' išklotinę, pasirinkite 'YouTube' duomenis, spustelėkite 'Keli formatai' ir pakeiskite istoriją iš HTML į JSON. Tada iš naujo atsisiųskite ir bandykite dar kartą.",
+            }
+        )
+        ok = props.Translatable(
+            {
+                "en": "Try again",
+                "de": "Erneut versuchen",
+                "it": "Riprova",
+                "es": "Inténtelo de nuevo",
+                "nl": "Probeer opnieuw",
+                "ro": "Încercați din nou",
+                "lt": "Bandyti dar kartą",
+            }
+        )
+        cancel = props.Translatable(
+            {
+                "en": "Continue",
+                "de": "Weiter",
+                "it": "Continua",
+                "es": "Continuar",
+                "nl": "Verder",
+                "ro": "Continuați",
+                "lt": "Tęsti",
+            }
+        )
+        return self.render_page([props.PropsUIPromptConfirm(text, ok, cancel)])
+
     def retry_confirmation_page(self, error_message=""):
         text = props.Translatable(
             {

--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -12,6 +12,11 @@ from port.parsers import ParseResult
 
 logger = logging.getLogger(__name__)
 
+
+class HtmlFormatError(Exception):
+    pass
+
+
 def process(session_id):
     key = "zip-youtube"
     page_renderer = PageRenderer()
@@ -37,6 +42,13 @@ def process(session_id):
             assert zip_ref, "Failed to open zip file"
             files = file_operations.get_files(zip_ref)
             assert files, "No files found in the zip archive"
+
+            html_history_files = [
+                f for f in files
+                if f.endswith("search-history.html") or f.endswith("watch-history.html")
+            ]
+            if html_history_files:
+                raise HtmlFormatError("History files are in HTML format, JSON format is required")
 
             relevant_files = [
                 f for f in files
@@ -69,6 +81,10 @@ def process(session_id):
             videos_parser.parse_files(extracted_files)
 
             break  # exit file submission loop on success file extraction
+
+        except HtmlFormatError as e:
+            logger.error("{}: HTML format detected ({})".format(key, str(e)))
+            yield page_renderer.html_format_retry_page()
 
         except AssertionError as e:
             logger.error("{}: extraction failed, retrying ({})".format(key, str(e)))

--- a/tests/donation.spec.ts
+++ b/tests/donation.spec.ts
@@ -113,6 +113,19 @@ test('can undo row removal before submission', async ({ page }) => {
   expect(submittedData).toEqual(expect.stringContaining("Some other title"));
 });
 
+test('shows HTML format error when history files are HTML', async ({ page }) => {
+  await page.goto('http://localhost:3000/');
+  await expect(page.getByRole('heading', { name: 'Youtube Data donation' })).toBeVisible({ timeout: 90000 });
+
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByText('Choose file').click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles(path.join(__dirname, 'test_html.zip'));
+  await page.getByText('Continue').click();
+
+  await expect(page.getByText('Multiple formats')).toBeVisible({ timeout: 30000 });
+});
+
 test('can cancel submission', async ({ page }) => {
   await setupTestWithFileUpload(page);
 

--- a/tests/test_html.zip
+++ b/tests/test_html.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c03cf59d77eeb035ed8f85786a11e62205797f22a01c0d3d958a6e5979ad637a
+size 1331


### PR DESCRIPTION
## Summary

- Detect when uploaded YouTube takeout zip contains history files in HTML format (instead of required JSON)
- Show a specific, actionable error message explaining how to re-download from Google Takeout with JSON format selected
- Translations added for EN, DE, IT, ES, NL, RO, LT
- Add e2e test covering this error path with a fake HTML takeout zip

Closes: https://3.basecamp.com/5734045/buckets/44165026/todos/9872986533

## Test plan

- [ ] Upload a YouTube takeout zip that contains `watch-history.html` or `search-history.html` — specific error with "Multiple formats" instruction appears
- [ ] Upload a valid JSON-format zip — normal flow continues unaffected
- [ ] E2e test `shows HTML format error when history files are HTML` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)