### PR TITLE
Remove cancel button from HTML format retry dialog

### DIFF
--- a/packages/feldspar/src/framework/types/prompts.ts
+++ b/packages/feldspar/src/framework/types/prompts.ts
@@ -20,10 +20,10 @@ export interface PropsUIPromptConfirm {
   __type__: 'PropsUIPromptConfirm'
   text: Text
   ok: Text
-  cancel: Text
+  cancel?: Text
 }
 export function isPropsUIPromptConfirm (arg: any): arg is PropsUIPromptConfirm {
-  return isInstanceOf<PropsUIPromptConfirm>(arg, 'PropsUIPromptConfirm', ['text', 'ok', 'cancel'])
+  return isInstanceOf<PropsUIPromptConfirm>(arg, 'PropsUIPromptConfirm', ['text', 'ok'])
 }
 
 export interface PropsUIPromptFileInput {

--- a/packages/feldspar/src/framework/visualization/react/ui/prompts/confirm.tsx
+++ b/packages/feldspar/src/framework/visualization/react/ui/prompts/confirm.tsx
@@ -26,7 +26,9 @@ export const Confirm = (props: Props): JSX.Element => {
       <BodyLarge text={text} margin='mb-4' />
       <div className='flex flex-row gap-4'>
         <PrimaryButton label={ok} onClick={handleOk} color='text-grey1 bg-tertiary' />
-        <PrimaryButton label={cancel} onClick={handleCancel} color='text-white bg-primary' />
+        {cancel !== undefined && (
+          <PrimaryButton label={cancel} onClick={handleCancel} color='text-white bg-primary' />
+        )}
       </div>
     </>
   )
@@ -35,13 +37,13 @@ export const Confirm = (props: Props): JSX.Element => {
 interface Copy {
   text: string
   ok: string
-  cancel: string
+  cancel: string | undefined
 }
 
 function prepareCopy ({ text, ok, cancel, locale }: Props): Copy {
   return {
     text: Translator.translate(text, locale),
     ok: Translator.translate(ok, locale),
-    cancel: Translator.translate(cancel, locale)
+    cancel: cancel !== undefined ? Translator.translate(cancel, locale) : undefined
   }
 }

--- a/packages/python/port/api/props.py
+++ b/packages/python/port/api/props.py
@@ -75,14 +75,15 @@ class PropsUIPromptConfirm:
 
     text: Translatable
     ok: Translatable
-    cancel: Translatable
+    cancel: Optional[Translatable] = None
 
     def toDict(self):
         dict = {}
         dict["__type__"] = "PropsUIPromptConfirm"
         dict["text"] = self.text.toDict()
         dict["ok"] = self.ok.toDict()
-        dict["cancel"] = self.cancel.toDict()
+        if self.cancel is not None:
+            dict["cancel"] = self.cancel.toDict()
         return dict
 
 

--- a/packages/python/port/rendering.py
+++ b/packages/python/port/rendering.py
@@ -45,18 +45,7 @@ class PageRenderer:
                 "lt": "Bandyti dar kartą",
             }
         )
-        cancel = props.Translatable(
-            {
-                "en": "Continue",
-                "de": "Weiter",
-                "it": "Continua",
-                "es": "Continuar",
-                "nl": "Verder",
-                "ro": "Continuați",
-                "lt": "Tęsti",
-            }
-        )
-        return self.render_page([props.PropsUIPromptConfirm(text, ok, cancel)])
+        return self.render_page([props.PropsUIPromptConfirm(text, ok)])
 
     def retry_confirmation_page(self, error_message=""):
         text = props.Translatable(

--- a/packages/python/tests/test_props_confirm.py
+++ b/packages/python/tests/test_props_confirm.py
@@ -1,0 +1,29 @@
+"""Tests for PropsUIPromptConfirm serialization — cancel is optional."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from port.api.props import PropsUIPromptConfirm, Translatable
+
+
+def _t(en: str) -> Translatable:
+    return Translatable({"en": en, "nl": en})
+
+
+def test_confirm_with_cancel_serializes_cancel():
+    prompt = PropsUIPromptConfirm(text=_t("Are you sure?"), ok=_t("Yes"), cancel=_t("No"))
+    d = prompt.toDict()
+    assert d["__type__"] == "PropsUIPromptConfirm"
+    assert d["ok"]["translations"]["en"] == "Yes"
+    assert "cancel" in d
+    assert d["cancel"]["translations"]["en"] == "No"
+
+
+def test_confirm_without_cancel_omits_cancel():
+    prompt = PropsUIPromptConfirm(text=_t("Try again?"), ok=_t("Try again"))
+    d = prompt.toDict()
+    assert d["__type__"] == "PropsUIPromptConfirm"
+    assert d["ok"]["translations"]["en"] == "Try again"
+    assert "cancel" not in d

--- a/tests/donation.spec.ts
+++ b/tests/donation.spec.ts
@@ -102,6 +102,27 @@ test('can undo row removal before submission', async ({ page }) => {
   expect(submittedData).toEqual(expect.stringContaining("Device A"));
 });
 
+test('shows confirm prompt when uploading a bad zip and can retry', async ({ page }) => {
+  await page.goto('http://localhost:3000/');
+  await expect(page.getByRole('heading', { name: 'Data donation flow example' })).toBeVisible({ timeout: 90000 });
+
+  // Upload a non-zip file to trigger the BadZipFile error path
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByText('Choose file').click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({ name: 'bad.zip', mimeType: 'application/zip', buffer: Buffer.from('not a zip') });
+
+  await page.getByText('Continue').click();
+
+  // The confirm prompt should appear with only the "Try again" button (no cancel)
+  await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible();
+  expect(await page.getByRole('button', { name: 'Cancel' }).count()).toBe(0);
+
+  // Clicking "Try again" should return to the file upload step
+  await page.getByRole('button', { name: 'Try again' }).click();
+  await expect(page.getByText('Choose file')).toBeVisible();
+});
+
 test('can cancel submission', async ({ page }) => {
   await setupTestWithFileUpload(page);
 

--- a/tests/donation.spec.ts
+++ b/tests/donation.spec.ts
@@ -128,7 +128,7 @@ test('shows HTML format error when history files are HTML', async ({ page }) => 
 
 test('shows confirm prompt when uploading a bad zip and can retry', async ({ page }) => {
   await page.goto('http://localhost:3000/');
-  await expect(page.getByRole('heading', { name: 'Data donation flow example' })).toBeVisible({ timeout: 90000 });
+  await expect(page.getByRole('heading', { name: 'Youtube Data donation' })).toBeVisible({ timeout: 90000 });
 
   // Upload a non-zip file to trigger the BadZipFile error path
   const fileChooserPromise = page.waitForEvent('filechooser');


### PR DESCRIPTION
## Summary
- Removes the "Continue" cancel button from the HTML format retry dialog — participants should not be able to bypass the format validation
- Syncs upstream feldspar change that makes `cancel` optional in `PropsUIPromptConfirm`
- Fixes upstream e2e test heading to match the YouTube script

Closes https://3.basecamp.com/5734045/buckets/44165026/todos/9881413124

## Test plan
- [x] All 6 e2e tests pass
- [x] HTML format error dialog shows only "Try again" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)